### PR TITLE
Add external host monitoring to Prometheus

### DIFF
--- a/gitops/apps/templates/kube-prometheus-stack.yaml
+++ b/gitops/apps/templates/kube-prometheus-stack.yaml
@@ -34,6 +34,19 @@ spec:
                     requests:
                       storage: 10Gi
 
+        # --- 外部ホスト監視 ---
+        additionalScrapeConfigs:
+          - job_name: "external-node"
+            static_configs:
+              - targets: ["192.168.100.17:9100"]
+                labels:
+                  instance: "devbox"
+          - job_name: "external-systemd"
+            static_configs:
+              - targets: ["192.168.100.17:9558"]
+                labels:
+                  instance: "devbox"
+
         # --- Grafana ---
         grafana:
           adminPassword: prom-operator

--- a/knowledge/external-host-monitoring-setup.md
+++ b/knowledge/external-host-monitoring-setup.md
@@ -1,0 +1,108 @@
+# 外部ホストの Prometheus 監視セットアップ手順
+
+k3s クラスター外のホストを kube-prometheus-stack の Prometheus で監視する手順。
+
+## 前提
+
+- kube-prometheus-stack が k3s クラスター内で稼働中
+- 対象ホストと k3s クラスターが同一ネットワーク内（192.168.100.0/24）
+
+## 手順
+
+### 1. 対象ホストに node-exporter をインストール
+
+CPU/メモリ/ディスク/ネットワークのメトリクスを収集する。
+
+```bash
+sudo apt-get install prometheus-node-exporter
+sudo systemctl enable --now prometheus-node-exporter
+```
+
+確認:
+
+```bash
+curl -s http://localhost:9100/metrics | head -5
+```
+
+### 2. 対象ホストに systemd-exporter をインストール
+
+systemd サービスの状態（起動状態、再起動回数等）を収集する。
+Debian パッケージにはないため、GitHub Releases からバイナリを取得。
+
+```bash
+# バイナリ取得（バージョンは適宜変更）
+cd /tmp
+curl -LO https://github.com/prometheus-community/systemd_exporter/releases/download/v0.7.0/systemd_exporter-0.7.0.linux-amd64.tar.gz
+tar xzf systemd_exporter-0.7.0.linux-amd64.tar.gz
+sudo cp systemd_exporter-0.7.0.linux-amd64/systemd_exporter /usr/local/bin/
+sudo chmod +x /usr/local/bin/systemd_exporter
+```
+
+systemd ユニットファイルを作成:
+
+```bash
+sudo tee /etc/systemd/system/systemd-exporter.service > /dev/null <<'EOF'
+[Unit]
+Description=Prometheus systemd Exporter
+After=network.target
+
+[Service]
+Type=simple
+ExecStart=/usr/local/bin/systemd_exporter
+Restart=always
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+sudo systemctl daemon-reload
+sudo systemctl enable --now systemd-exporter
+```
+
+確認:
+
+```bash
+curl -s http://localhost:9558/metrics | head -5
+```
+
+### 3. Prometheus の scrape 設定を追加（GitOps）
+
+`gitops/apps/templates/kube-prometheus-stack.yaml` の `valuesObject.prometheus.prometheusSpec` に `additionalScrapeConfigs` を追加:
+
+```yaml
+additionalScrapeConfigs:
+  - job_name: "external-node"
+    static_configs:
+      - targets: ["<HOST_IP>:9100"]
+        labels:
+          instance: "<HOST_NAME>"
+  - job_name: "external-systemd"
+    static_configs:
+      - targets: ["<HOST_IP>:9558"]
+        labels:
+          instance: "<HOST_NAME>"
+```
+
+Git push → ArgoCD が自動同期（約3分）→ Prometheus がスクレイプ開始。
+
+### 4. 動作確認
+
+- Grafana (`http://grafana.homelab.local`) で対象ホストのメトリクスが表示されること
+- Dashboards → 「Node Exporter / Nodes」で対象ホストを選択できること
+
+## 監視済みホスト
+
+| ホスト名 | IP | node-exporter | systemd-exporter |
+|---------|-----|--------------|-----------------|
+| devbox | 192.168.100.17 | :9100 | :9558 |
+
+## 他のホストを追加する場合
+
+1. 対象ホストで手順 1〜2 を実施
+2. `additionalScrapeConfigs` の `targets` にホストを追加して Git push
+
+## 参考
+
+- https://github.com/prometheus-community/systemd_exporter
+- https://github.com/prometheus/node_exporter

--- a/knowledge/til/20260223-observability-lgtm-stack.md
+++ b/knowledge/til/20260223-observability-lgtm-stack.md
@@ -1,0 +1,29 @@
+---
+title: "Observability は Grafana LGTM スタック + OpenTelemetry に収束しつつある"
+type: discovery
+tags: [observability, grafana, opentelemetry, lgtm]
+created: 2026-02-23
+source: session
+---
+
+2025-2026 年の Observability トレンド:
+
+- **OpenTelemetry** が事実上の標準に。GitHub コミット数が前年比 45% 増
+- **LGTM スタック** が Grafana エコシステムの中核:
+  - L: Loki（ログ）
+  - G: Grafana（可視化）
+  - T: Tempo（トレース）
+  - M: Mimir（メトリクス、Prometheus 互換）
+- AI × Observability: 84% の組織が検討/パイロット中（2025年調査）
+
+homelab での発展パス:
+1. kube-prometheus-stack (M + G) ← 今ここ
+2. Loki (L) ← 次のステップ
+3. Tempo (T) ← アプリが増えたら
+4. OpenTelemetry Collector で統一的にデータ収集
+
+## 参考
+
+- https://grafana.com/blog/2026-observability-trends-predictions-from-grafana-labs-unified-intelligent-and-open/
+- https://grafana.com/observability-survey/2025/
+- https://thenewstack.io/can-opentelemetry-save-observability-in-2026/

--- a/knowledge/til/20260223-prometheus-external-host.md
+++ b/knowledge/til/20260223-prometheus-external-host.md
@@ -1,0 +1,34 @@
+---
+title: "k8s 外のホストを Prometheus で監視する方法"
+type: discovery
+tags: [prometheus, node-exporter, systemd-exporter, monitoring]
+created: 2026-02-23
+source: session
+---
+
+k8s クラスター外のホストを kube-prometheus-stack の Prometheus で監視するパターン:
+
+1. 対象ホストに exporter をインストール
+   - `node-exporter` (:9100) → CPU/メモリ/ディスク/ネットワーク
+   - `systemd-exporter` (:9558) → systemd サービスの状態
+
+2. Prometheus の `additionalScrapeConfigs` に targets を追加
+
+```yaml
+prometheus:
+  prometheusSpec:
+    additionalScrapeConfigs:
+      - job_name: "external-node"
+        static_configs:
+          - targets: ["192.168.100.17:9100"]
+            labels:
+              instance: "devbox"
+```
+
+GitOps で管理している場合、Application YAML の valuesObject に追記して Git push するだけで ArgoCD が自動反映する。
+
+Debian の場合、node-exporter は `apt install prometheus-node-exporter` で入る。systemd-exporter は GitHub Releases からバイナリを取得して systemd ユニットを手動作成する必要がある。
+
+## 参考
+
+- https://github.com/prometheus-community/systemd_exporter

--- a/knowledge/til/20260223-tempo-vs-jaeger.md
+++ b/knowledge/til/20260223-tempo-vs-jaeger.md
@@ -1,0 +1,15 @@
+---
+title: "Tempo は Jaeger の後継的立ち位置（インデックス不要が最大の違い）"
+type: comparison
+tags: [observability, tracing, tempo, jaeger, grafana]
+created: 2026-02-23
+source: session
+---
+
+選択肢: Jaeger vs Tempo（分散トレーシング）
+
+判断基準:
+- Jaeger: Elasticsearch か Cassandra が必要（インデックス用）。運用コストが高い
+- Tempo: インデックス不要。オブジェクトストレージやローカルディスクに直接書き込む。軽量
+
+結論: Grafana スタック（LGTM）を使っているなら Tempo 一択。Grafana とネイティブ統合されており、メトリクス → トレースのシームレスな連携ができる。homelab のようなリソースが限られた環境では特に Tempo の軽量さが活きる。


### PR DESCRIPTION
## Summary
- devbox ホスト (192.168.100.17) を Prometheus の監視対象に追加
- node-exporter (:9100) と systemd-exporter (:9558) の scrape 設定を `additionalScrapeConfigs` に追加

Closes #13

## 対象ホストでの事前作業（実施済み）
- [x] node-exporter インストール (`apt install prometheus-node-exporter`)
- [x] systemd-exporter v0.7.0 インストール（バイナリ + systemd ユニット）

## マージ後の動作
Git push → ArgoCD が自動同期 → Prometheus が新しいターゲットをスクレイプ開始

## Test plan
- [ ] ArgoCD で kube-prometheus-stack が Synced/Healthy
- [ ] Prometheus Targets に external-node / external-systemd が UP
- [ ] Grafana で devbox の CPU/メモリ/ディスクが表示される
- [ ] systemd サービスの状態が確認できる

🤖 Generated with [Claude Code](https://claude.com/claude-code)